### PR TITLE
Add token lifetime parameter to be able to override default expiration

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,25 @@ parameter `gcp_token_lifetime` in the `TokenService`. Check the
 [API docs](https://cloud.google.com/iam/docs/creating-short-lived-service-account-credentials#sa-credentials-oauth) 
 for valid values and required configurations.
 
+```python
+from scalesec_gcp_workload_identity.main import TokenService
+from os import getenv
+
+# The default lifetime of 1h can be overridden to use
+# a different duration.
+
+token_service = TokenService(
+  gcp_project_number=getenv('GCP_PROJECT_NUMBER'),
+  gcp_workload_id=getenv('GCP_WORKLOAD_ID'),
+  gcp_workload_provider=getenv('GCP_WORKLOAD_PROVIDER'),
+  gcp_service_account_email=getenv('GCP_SERVICE_ACCOUNT_EMAIL'),
+  aws_account_id=getenv('AWS_ACCOUNT_ID'),
+  aws_role_name=getenv('AWS_ROLE_NAME'),
+  aws_region=getenv('AWS_REGION'),
+  gcp_token_lifetime='21600s' # 6 hours
+)
+```
+
 ## Testing
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -103,6 +103,11 @@ token_service = TokenService(
 sa_token, expiry_date = token_service.get_token()
 ```
 
+The default expiry_date is 1h in GCP. This behaviour can be changed by overriding the 
+parameter `gcp_token_lifetime` in the `TokenService`. Check the 
+[API docs](https://cloud.google.com/iam/docs/creating-short-lived-service-account-credentials#sa-credentials-oauth) 
+for valid values and required configurations.
+
 ## Testing
 
 ```shell

--- a/scalesec_gcp_workload_identity/main.py
+++ b/scalesec_gcp_workload_identity/main.py
@@ -22,7 +22,8 @@ class TokenService: #pylint: disable=too-many-instance-attributes
         gcp_service_account_email: str,
         aws_account_id: str,
         aws_role_name: str,
-        aws_region: str
+        aws_region: str,
+        gcp_token_lifetime: str = "3600s"
         ) -> None:
 
         # GCP
@@ -30,6 +31,7 @@ class TokenService: #pylint: disable=too-many-instance-attributes
         self.gcp_workload_id = gcp_workload_id
         self.gcp_provider = gcp_workload_provider
         self.gcp_service_account_email = gcp_service_account_email
+        self.gcp_token_lifetime = gcp_token_lifetime
 
         self.gcp_federated_token = None
         self.gcp_sa_token = None
@@ -93,6 +95,6 @@ class TokenService: #pylint: disable=too-many-instance-attributes
             )
 
         # get the SA token
-        self.gcp_sa_token, sa_expire_time = self.utils._get_sa_token(federated_access_token) #pylint: disable=protected-access
+        self.gcp_sa_token, sa_expire_time = self.utils._get_sa_token(federated_access_token, self.gcp_token_lifetime) #pylint: disable=protected-access
 
         return self.gcp_sa_token, sa_expire_time

--- a/scalesec_gcp_workload_identity/utils.py
+++ b/scalesec_gcp_workload_identity/utils.py
@@ -224,7 +224,7 @@ class Utils: #pylint: disable=too-many-instance-attributes,too-few-public-method
 
         return federated_token
 
-    def _get_sa_token(self, federated_token: str) -> Tuple[str, str]:
+    def _get_sa_token(self, federated_token: str, gcp_token_lifetime: str) -> Tuple[str, str]:
         """
         Exchanges a federated token (limited service support) for a a better supported SA token
 
@@ -239,7 +239,8 @@ class Utils: #pylint: disable=too-many-instance-attributes,too-few-public-method
         body = {
             "scope": [
                 "https://www.googleapis.com/auth/cloud-platform"
-            ]
+            ],
+            "lifetime": gcp_token_lifetime
         }
 
         # Add json headers and send the request


### PR DESCRIPTION
The default expiration time for oauth 2.0 access tokens is 1h in GCP,
https://cloud.google.com/iam/docs/creating-short-lived-service-account-credentials#sa-credentials-oauth

There are some use cases that might require a longer time. GCP does allow extending the lifetime for certain service accounts with an organisation constraint.

The changes below add an additional `gcp_token_lifetime` parameter to the `TokenService` with a default value that matches the default one in GCP. It can be set in case it needs to be extended after the organisation policy is configured.

I can also adapt the documentation if you want to include it.