### PR TITLE
Enable using a different set of scopes for the generated token

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ export AWS_REGION=
 export AWS_ACCOUNT_ID=
 export AWS_ROLE_NAME=
 
-# Token expiry
+# Non-required vars
 export TOKEN_LIFETIME=
+export TOKEN_SCOPES=
 EOF
 ```
 
@@ -110,8 +111,8 @@ token_service = TokenService(
   aws_account_id=getenv('AWS_ACCOUNT_ID'),
   aws_role_name=getenv('AWS_ROLE_NAME'),
   aws_region=getenv('AWS_REGION'),
-  gcp_token_lifetime=getenv('TOKEN_LIFETIME'),
-  gcp_token_scopes=getenv('TOKEN_SCOPES')
+  gcp_token_lifetime=getenv('TOKEN_LIFETIME'), # Not required
+  gcp_token_scopes=getenv('TOKEN_SCOPES') # Not required
 )
 
 sa_token, expiry_date = token_service.get_token()

--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ token_service = TokenService(
   aws_account_id=getenv('AWS_ACCOUNT_ID'),
   aws_role_name=getenv('AWS_ROLE_NAME'),
   aws_region=getenv('AWS_REGION'),
-  gcp_token_lifetime=getenv('TOKEN_LIFETIME')
+  gcp_token_lifetime=getenv('TOKEN_LIFETIME'),
+  gcp_token_scopes=getenv('TOKEN_SCOPES')
 )
 
 sa_token, expiry_date = token_service.get_token()
@@ -134,6 +135,9 @@ spec:
       - your-sa@yourproject.iam.gserviceaccount.com
 ```
 
+#### Token scopes
+
+The default scope for the service account token is `https://www.googleapis.com/auth/cloud-platform`. This behaviour can be overridden to enable a different set of scopes by using the environment variable `TOKEN_SCOPES` in the `.env` file.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ spec:
 
 #### Token scopes
 
-The default scope for the service account token is `https://www.googleapis.com/auth/cloud-platform`. This behaviour can be overridden to enable a different set of scopes by using the environment variable `TOKEN_SCOPES` in the `.env` file.
+The default scope for the service account token is `https://www.googleapis.com/auth/cloud-platform`. This behaviour can be overridden to enable a different set of scopes by using the environment variable `TOKEN_SCOPES` in the `.env` file with a comma-separated list of GCP scopes.
 
 ## Testing
 

--- a/examples/gcs_list_bucket/main.py
+++ b/examples/gcs_list_bucket/main.py
@@ -28,7 +28,6 @@ def gcs_object_lister():
         aws_account_id=getenv('AWS_ACCOUNT_ID'),
         aws_role_name=getenv('AWS_ROLE_NAME'),
         aws_region=getenv('AWS_REGION'),
-        gcp_token_lifetime=getenv('TOKEN_LIFETIME')
     )
 
     # Return our GCP SA access token

--- a/scalesec_gcp_workload_identity/main.py
+++ b/scalesec_gcp_workload_identity/main.py
@@ -23,7 +23,8 @@ class TokenService: #pylint: disable=too-many-instance-attributes
         aws_account_id: str,
         aws_role_name: str,
         aws_region: str,
-        gcp_token_lifetime: str = "3600s"
+        gcp_token_lifetime: str = "3600s",
+        gcp_token_scopes: str = "https://www.googleapis.com/auth/cloud-platform"
         ) -> None:
 
         # GCP
@@ -32,6 +33,7 @@ class TokenService: #pylint: disable=too-many-instance-attributes
         self.gcp_provider = gcp_workload_provider
         self.gcp_service_account_email = gcp_service_account_email
         self.gcp_token_lifetime = gcp_token_lifetime
+        self.gcp_token_scopes = gcp_token_scopes
 
         self.gcp_federated_token = None
         self.gcp_sa_token = None
@@ -95,6 +97,6 @@ class TokenService: #pylint: disable=too-many-instance-attributes
             )
 
         # get the SA token
-        self.gcp_sa_token, sa_expire_time = self.utils._get_sa_token(federated_access_token, self.gcp_token_lifetime) #pylint: disable=protected-access
+        self.gcp_sa_token, sa_expire_time = self.utils._get_sa_token(federated_access_token, self.gcp_token_lifetime, self.gcp_token_scopes) #pylint: disable=protected-access
 
         return self.gcp_sa_token, sa_expire_time

--- a/scalesec_gcp_workload_identity/utils.py
+++ b/scalesec_gcp_workload_identity/utils.py
@@ -224,7 +224,7 @@ class Utils: #pylint: disable=too-many-instance-attributes,too-few-public-method
 
         return federated_token
 
-    def _get_sa_token(self, federated_token: str, gcp_token_lifetime: str) -> Tuple[str, str]:
+    def _get_sa_token(self, federated_token: str, gcp_token_lifetime: str, gcp_token_scopes: str) -> Tuple[str, str]:
         """
         Exchanges a federated token (limited service support) for a a better supported SA token
 
@@ -237,9 +237,7 @@ class Utils: #pylint: disable=too-many-instance-attributes,too-few-public-method
 
         # Create the body for our token exchange request
         body = {
-            "scope": [
-                "https://www.googleapis.com/auth/cloud-platform"
-            ],
+            "scope": gcp_token_scopes.split(","),
             "lifetime": gcp_token_lifetime
         }
 


### PR DESCRIPTION
The current library implementation does hardcode the scopes for a given service account to `https://www.googleapis.com/auth/cloud-platform`. This is not going to allow using that token for actions that require additional scopes such as creating an external table in BigQuery that uses a drive document.

See for example how scopes are provided when using oauth for the same use case,
https://docs.getdbt.com/reference/warehouse-profiles/bigquery-profile#local-oauth-gcloud-setup

This change does set up an additional parameter to the `TokenService` that maintains the default value and does allow users to set their own list of scopes (a comma-separated string of GCP scopes).